### PR TITLE
Add assumes entry in metadata to define as a k8s charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,3 +21,6 @@ resources:
   spring-boot-app-image:
     type: oci-image
     description: Spring Boot application image.
+
+assumes:
+  - k8s-api


### PR DESCRIPTION
As the subject suggests, this will ensure the charm isn't deployable on machine substrates.