### PR TITLE
Handle spring_boot_app_pebble_ready event

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "DCO060"]
+ignore = ["W503", "E501", "D107"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = [
     "tests/*:D100,D101,D102,D103,D104,D205,D212,D415",

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,7 +26,11 @@ JAVA_TOOL_OPTIONS = "JAVA_TOOL_OPTIONS"
 
 
 class SpringBootCharm(CharmBase):
-    """Spring Boot Charm service."""
+    """Spring Boot Charm service.
+
+    Attrs:
+        on: Allows for subscribing to CharmEvents
+    """
 
     on = CharmEvents()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,7 @@ import typing
 
 import kubernetes.client
 import ops.charm
-from ops.charm import CharmBase, EventBase
+from ops.charm import CharmBase, CharmEvents, EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import ExecError
@@ -28,6 +28,8 @@ JAVA_TOOL_OPTIONS = "JAVA_TOOL_OPTIONS"
 class SpringBootCharm(CharmBase):
     """Spring Boot Charm service."""
 
+    on = CharmEvents()
+
     def __init__(self, *args: typing.Any) -> None:
         """Initialize the instance.
 
@@ -36,6 +38,7 @@ class SpringBootCharm(CharmBase):
         """
         super().__init__(*args)
         self.framework.observe(self.on.config_changed, self.reconciliation)
+        self.framework.observe(self.on.spring_boot_app_pebble_ready, self.reconciliation)
 
     def _application_config(self) -> dict | None:
         """Decode the value of the charm configuration application-config.

--- a/src/charm_types.py
+++ b/src/charm_types.py
@@ -9,7 +9,7 @@ from typing import NamedTuple
 class ExecResult(NamedTuple):
     """Command execution result.
 
-    Args:
+    Attrs:
         exit_code: command exit code.
         stdout: command stdout.
         stderr: command stderr.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -300,6 +300,11 @@ def test_pebble_ready(
     harness: Harness,
     patch: SpringBootPatch,
 ):
+    """
+    arrange: provide a simulated Spring Boot application image.
+    act: set pebble as ready.
+    assert: the unit should have the ActiveStatus
+    """
     patch.start(
         {"spring-boot-app": OCIImageMock.builder().add_file("/app/test.jar", b"").build()},
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -296,10 +296,7 @@ def test_jvm_heap_memory_config(
         )
 
 
-def test_pebble_ready(
-    harness: Harness,
-    patch: SpringBootPatch,
-):
+def test_pebble_ready(harness: Harness, patch: SpringBootPatch):
     """
     arrange: provide a simulated Spring Boot application image.
     act: set pebble as ready.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -294,3 +294,15 @@ def test_jvm_heap_memory_config(
             "Invalid jvm-config, "
             "Java heap memory specification exceeds application memory constraint"
         )
+
+
+def test_pebble_ready(
+    harness: Harness,
+    patch: SpringBootPatch,
+):
+    patch.start(
+        {"spring-boot-app": OCIImageMock.builder().add_file("/app/test.jar", b"").build()},
+    )
+    harness.begin_with_initial_hooks()
+    harness.container_pebble_ready("spring-boot-app")
+    assert isinstance(harness.model.unit.status, ActiveStatus)


### PR DESCRIPTION
The charm wasn't getting the ActiveStatus without changing some config. This is fixed by handling the spring_boot_app_pebble_ready event with the reconciliation() method.