### PR TITLE
Pin libjuju to version 2

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,2 +1,3 @@
 ops >= 1.5.0
+juju>=2,<3
 pytest_operator


### PR DESCRIPTION
Pin libjuju to version 2 since version 3 breaks compatibility https://github.com/juju/python-libjuju/releases/tag/3.1.0.1